### PR TITLE
Avoid double rel attribute values, if already set

### DIFF
--- a/Classes/Hooks/LinkHook.php
+++ b/Classes/Hooks/LinkHook.php
@@ -38,7 +38,7 @@ class LinkHook
                     GeneralUtility::trimExplode(' ', $relAttribute),
                     GeneralUtility::trimExplode(' ', $params['tagAttributes']['rel'])
                 )));
-                $params['finalTag'] = str_replace('rel="', 'rel="' . $relAttribute . ' ', $params['finalTag']);
+                $params['finalTag'] = preg_replace('/rel=\"(.*?)\"/', 'rel="' . $params['tagAttributes']['rel'] . '"', $params['finalTag']);
             }
         }
     }


### PR DESCRIPTION
Extension Version 1.0.1
TYPO3 version 8.7

In case, a link to external domain is configured with TypoScript, including preconfigured rel attributes 'noopener' or 'noreferrer' or both, rel attribute results in double values.

TypoScript example
```
typolink {
  parameter = https://www.domain.tld
  ATagParams = rel="noopener noreferrer nofollow"
}
```
Result is
```
<a href="https://www.domain.tld" target="_blank" rel="noopener noreferrer noopener noreferrer nofollow">https://www.domain.tld</a>
```
Expected
```
<a href="https://www.domain.tld" target="_blank" rel="noopener noreferrer nofollow">https://www.domain.tld</a>
```

This change, replaces rel attribute with expected values and avoids double values.